### PR TITLE
Update summaries to fit better in our Postman collection

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -884,7 +884,7 @@ paths:
   /cars/search-airport:
     get:
       operationId: Car Rental Airport Search
-      summary: Car Rental Airport Search - Provide an airport code, as well as the pick-up and drop-off dates, and get a list of car rental providers with their locations and rates. Optional parameters such as currency and rental provider codes are also available and can be used to narrow down the results. This API is an ideal pairing with the flight and hotel search to provide ground transportation options at the destination.
+      summary: Car Rental Airport Search - Find car rental providers and rates when you provide an airport code, as well as the pick-up and drop-off dates. Optional parameters such as currency and rental provider codes are also available and can be used to narrow down the results. This API is an ideal pairing with the flight and hotel search to provide ground transportation options at the destination.
       description: |
         <p>With this API you can find out the price and type of car, for all car rental providers, near a specified airport.</p>
 
@@ -974,7 +974,7 @@ paths:
   /cars/search-circle:
     get:
       operationId: Car Rental Geosearch
-      summary: Car Rental Geosearch - Define a circular area with one coordinate and radius, as well as the pick-up and drop-off dates, and get a list of car rental providers with their locations and rates. Optional parameters such as currency and rental provider codes are also available and can be used to narrow down the results. This API is an ideal pairing with the flight and hotel search to provide ground transportation options at the destination.
+      summary: Car Rental Geosearch - Locate car rental providers and available vehicles when you define a circular area with one coordinate and radius, as well as the pick-up and drop-off dates. Optional parameters such as currency and rental provider codes are also available and can be used to narrow down the results. This API is an ideal pairing with the flight and hotel search to provide ground transportation options at the destination.
       description: | 
         <p>With this API you can find out the price and type of car, for all car rental providers, in a specified geographical location.</p>
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -18,7 +18,7 @@ paths:
   /flights/inspiration-search:
     get:
       operationId: Flight Inspiration Search
-      summary: The Flight Inspiration Search API lets you go beyond the traditional search by origin, destination and dates to meet the needs of travelers looking for suggestions and a search experience that reflects the way they choose their trip. This can help you answer the question "Where can I go within a given travel budget?" 
+      summary: Flight Inspiration Search - Go beyond the traditional search by origin, destination and dates to meet the needs of travelers looking for suggestions and a search experience that reflects the way they choose their trip. This can help you answer the question "Where can I go within a given travel budget?" 
       description: |
         <p>The Inspiration Flight Search allows you to find the prices of one-way and return flights from an origin city without necessarily having a destination, or even a flight date, in mind. The search doesn't return a distinct set of price options, but rather, can tell you the price of flying from a given city to some destination, for a trip of a given duration, that falls within a given date range.</p>
 
@@ -90,7 +90,7 @@ paths:
   /flights/extensive-search:
     get:
       operationId: Flight Extensive Search
-      summary: The Extensive Flight Search API allows building travel searches based on very flexible and open range of dates. You can use it to answer questions such as "When is the best date to fly...".  It's built on Amadeus' Featured Results technology, which returns thousands of results (prices, itineraries and dates) in a matter of milliseconds. Results are available over half a calendar year with a 1 to 15 day stay duration    
+      summary: Flight Extensive Search - Build travel searches based on very flexible and open range of dates. You can use it to answer questions such as "When is the best date to fly...".  It's built on Amadeus' Featured Results technology, which returns thousands of results (prices, itineraries and dates) in a matter of milliseconds. Results are available over half a calendar year with a 1 to 15 day stay duration
       description: |
         <p>The Extensive Flight Search allows you to find the prices of one-way or return flights between two airports over a large number of dates, and for a large variety of stay durations. The search doesn't return exact itineraries, but rather tells you the best price for a flight on a given day, for a stay of a given duration.</p>
 
@@ -164,7 +164,7 @@ paths:
   /flights/low-fare-search:
     get:
       operationId: Flight Low-Fare Search   
-      summary: The Low-Fare Search API lets you find the cheapest one way or return itineraries and fares between two airports at specific dates.
+      summary: Flight Low-Fare Search - Find the cheapest one way or return itineraries and fares between two airports at specific dates.
       description: |
           <p>This is the low fare search engine Amadeus uses to retrieve the best price for flights, based on our latest Master Pricer Travel Board technology. This document describes how to make a low fare search and how to handle the returned messages.</p>
           
@@ -290,7 +290,7 @@ paths:
   /flights/affiliate-search:
     get:
       operationId: Flight Affiliate Search   
-      summary: The  Flight Affiliate Search API uses Travel Audience Connect's affiliate network API to search flights from our list of partners and provides deep-links to allow the user to book directly on the airline website.
+      summary: Flight Affiliate Search - Use Travel Audience Connect's affiliate network API to search flights from our list of partners and provides deep-links to allow the user to book directly on the airline website.
       description: |
           <p>The Flight Affiliate Search API combines Amadeus' flight search technology with Travel Audience's Connect API partners to provide a unique flight search, where all results come with deep-links to book the flight at a partner's website. The API will let you easily provide the traveler with a path to book flights from your application.</p>
           <p>Travel Audience Connect partners include
@@ -396,7 +396,7 @@ paths:
   /location/{code}:
     get:
       operationId: Location Information
-      summary: The Location Information API allows you to quickly find out more information about any IATA city or airport location code. With this API, you can find information such as city and airport names and locations, as well as information on timezones and airport usage.
+      summary: Location Information - Find more information about any IATA city or airport location code. With this API, you can find information such as city and airport names and locations, as well as information on timezones and airport usage.
       description: |
         <p>This service retrieves the location information corresponding to a IATA city or airport code.</p>
       
@@ -427,7 +427,7 @@ paths:
   /airports/autocomplete:
     get:
       operationId: Airport Autocomplete
-      summary: The Airport Autocomplete API provides a simple means to find an IATA location code for flight search based on a city or airport name. The API is fully JQuery-Autocomplete compatible to enable you to quickly build a drop-down list for your users to find the right airport easily. 
+      summary: Airport Autocomplete - Find an IATA location code for flight search based on a city or airport name. The API is fully JQuery-Autocomplete compatible to enable you to quickly build a drop-down list for your users to find the right airport easily. 
       description: |
         <p>Given the start of any word in an airport's official name, a city name, or the start of an <a href="https://en.wikipedia.org/wiki/International_Air_Transport_Association_airport_code">IATA code</a>, this API provides the full name and IATA location code of the city or airport, for use in flight searches. Only major cities and civilian airports with several commercial flights per week are included by default. The response provides up to 20 possible matches, sorted by importance, in a <a href="http://jqueryui.com/autocomplete/">JQuery UI Autocomplete</a> compatible format. <a href="https://github.com/amadeus-travel-innovation-sandbox/sandbox-content/blob/master/airport-autocomplete-template.html">This sample implementation</a> using JQuery UI may help. This API uses data from the <a href="https://github.com/opentraveldata/opentraveldata/blob/master/opentraveldata/optd_por_public.csv">OpenTravelData</a> project.</p>
 
@@ -458,7 +458,7 @@ paths:
   /airports/nearest-relevant:
     get:
       operationId: Nearest Relevant Airport
-      summary: The Nearest Relevant Airport can find the most useful nearby airport to a given location.
+      summary: Nearest Relevant Airport - Find the most useful nearby airport to a given location.
       description: |
         <p>This service gives the most relevant airports in a radius of 500 km around the given coordinates. The relevance of an airport is computed by dividing the number of airport movements (take offs and landings) by the distance from the point. This causes the relevance of an airport to increase exponentially as you approach it.</p>
 
@@ -499,7 +499,7 @@ paths:
   /hotels/search-airport:
     get:
       operationId: Hotel Airport Search
-      summary: The Hotel Airport Search API uses Amadeus' fast hotel search engine to locate the cheapest available rooms near a given airport, for a given stay period. This API is ideal if you want to connect flight and hotels. Provide an IATA airport code, as well as the check-in and check-out dates, and get a list of up to 140 properties (names, codes, image, amenities) with their locations and rates. Optional parameters such as currency and maximum rates, amenities or hotel chain codes are also available and can be used to narrow down the results. More optional parameters such as show_sold_out & rooms can be used to show sold out rooms and all available rooms. 
+      summary: Hotel Airport Search - Locate the cheapest available rooms near a given airport, for a given stay period. This API is ideal if you want to connect flight and hotels. Provide an IATA airport code, as well as the check-in and check-out dates, and get a list of up to 140 properties (names, codes, image, amenities) with their locations and rates. Optional parameters such as currency and maximum rates, amenities or hotel chain codes are also available and can be used to narrow down the results. More optional parameters such as show_sold_out & rooms can be used to show sold out rooms and all available rooms. 
       description: |
         <p>A fast Hotel shopping API to see which hotels are available in a given area, on a given day and displays their lowest prices. With this API you can find out the price of the cheapest daily rate for all hotels near a given airport.</p>
     
@@ -597,7 +597,7 @@ paths:
   /hotels/search-circle:
     get:
       operationId: Hotel Geosearch by circle
-      summary: The Hotel Lowest-Price Search API uses Amadeus' fast hotel search engine to locate the cheapest available rooms within a given radius of a defined point for a given stay period.
+      summary: Hotel Geosearch by Circle API - Locate the cheapest available rooms within a given radius of a defined point for a given stay period.
       description: | 
         <p>A fast Hotel shopping API to see which hotels are available in a given area, on a given day and displays their lowest prices. With this API you can find out the price of the cheapest daily rate for all hotels within a specified radius of a point.</p>
       
@@ -703,7 +703,7 @@ paths:
   /hotels/search-box:
     get:
       operationId: Hotel Geosearch by box
-      summary: The Hotel Lowest-Price Search API uses Amadeus' fast hotel search engine to locate the cheapest available rooms within a given rectangular region for a given stay period. It's ideal for displaying results on a map.
+      summary: Hotel Geosearch by box - Locate the cheapest available rooms within a given rectangular region for a given stay period. It's ideal for displaying results on a map.
       description: |
         <p>A fast Hotel shopping API to see which hotels are available in a given area, on a given day and displays their lowest prices. With this API you can find out the price of the cheapest daily rate for all hotels within a specified geographical region.</p>
         
@@ -803,7 +803,7 @@ paths:
   /hotels/{property_code}:
     get:
       operationId: Hotel Property Code Search   
-      summary: Once you have found your preferred hotel, our Hotel Property Code Search API allows you to quickly find out more room and rate information. It's ideal for displaying results on a map.
+      summary: Hotel Property Code Search - Find out more room and rate information once you have found your preferred hotel.
       description: |
         <p>This API allows you to quickly see the detailed information of a single hotel, including descriptions, address, GPS location, amenities, awards, lowest priced room and all room prices and booking information. </p>
 
@@ -870,7 +870,7 @@ paths:
   /cars/search-airport:
     get:
       operationId: Car Rental Airport Search
-      summary: The Car Rental API uses Amadeus' classic car service to locate the best available car. Define a circular area with one coordinate and radius, or provide an airport code, as well as the pick-up and drop-off dates, and get a list of car rental providers with their locations and rates. Optional parameters such as currency and rental provider codes are also available and can be used to narrow down the results. This API is an ideal pairing with the flight and hotel search to provide ground transportation options at the destination.
+      summary: Car Rental Airport Search - Provide an airport code, as well as the pick-up and drop-off dates, and get a list of car rental providers with their locations and rates. Optional parameters such as currency and rental provider codes are also available and can be used to narrow down the results. This API is an ideal pairing with the flight and hotel search to provide ground transportation options at the destination.
       description: |
         <p>With this API you can find out the price and type of car, for all car rental providers, near a specified airport.</p>
 
@@ -960,7 +960,7 @@ paths:
   /cars/search-circle:
     get:
       operationId: Car Rental Geosearch
-      summary: The Car Rental API uses Amadeus' car service to locate the best available car. Define a circular area with one coordinate and radius, or provide an airport code, as well as the pick-up and drop-off dates, and get a list of car rental providers with their locations and rates. Optional parameters such as currency and rental provider codes are also available and can be used to narrow down the results. This API is an ideal pairing with the flight and hotel search to provide ground transportation options at the destination.
+      summary: Car Rental Geosearch - Define a circular area with one coordinate and radius, as well as the pick-up and drop-off dates, and get a list of car rental providers with their locations and rates. Optional parameters such as currency and rental provider codes are also available and can be used to narrow down the results. This API is an ideal pairing with the flight and hotel search to provide ground transportation options at the destination.
       description: | 
         <p>With this API you can find out the price and type of car, for all car rental providers, in a specified geographical location.</p>
 
@@ -1062,7 +1062,7 @@ paths:
   /rail-stations/autocomplete:
     get:
       operationId: Rail-Station Autocomplete
-      summary: Use the Rail Station Autocomplete API to transform user input into a unique rail station code.
+      summary: Rail Station Autocomplete - Transform user input into a unique rail station code. Currently only French and Italian stations are supported.
       description:  |
         <p>Given the start of any word in a rail station's official name, as a term, this API provides the full name and rail station ID of a rail station for use in searches. The response provides an array of up to 20 possible matches, sorted by passenger traffic, in a JQuery Autocomplete compatible format.</p>
 
@@ -1095,7 +1095,7 @@ paths:
   /rail-station/{id}:
     get:
       operationId: Rail-Station Information
-      summary: This service retrieves the rail station information corresponding to an Amadeus UIC rail station ID. Currently only French and Italian stations are supported.
+      summary: Rail-Station Information - Retrieve the rail station information corresponding to an Amadeus UIC rail station ID. Currently only French and Italian stations are supported.
       parameters:
         - name: apikey
           in: query
@@ -1120,7 +1120,7 @@ paths:
   /trains/extensive-search:
     get:
       operationId: Train Extensive Search
-      summary:  Our instant extensive train search will provide you with multi-day availability and a variety of schedule and pricing options to travel to your destination.
+      summary:  Train Extensive Search - Provides multi-day availability and a variety of schedule and pricing options to travel to your destination instantly. Supports SNCF French trains only.
       description:  |
         <p>This API allows you to search trains availability and prices for a single day or date range. It's based on our Rail Instant Search technology, providing you with immediate results from our rail search cache.</p>
 
@@ -1163,7 +1163,7 @@ paths:
   /trains/schedule-search:
     get:
       operationId: Train Schedule Search
-      summary: The train schedule search can suggest destinations from your chosen departure station
+      summary: Train Schedule Search - Suggest destinations from your chosen departure station. Supports SNCF French Rail only.
       description:  |
         <p>This API allows you to find all the possible destinations in the Rail Instant Search cache (used by Extensive Search above) from a given origin station on a given day. You can use this to help build network maps, journey planners or provide inspiration for rail travel.</p>
 
@@ -1202,7 +1202,7 @@ paths:
   /travel-record/{record_locator}:
     get:
       operationId: Travel Record Retrieve
-      summary: "Amadeus has one of the world's largest repositories of travel records. Enable travelers to explore the details of their journeys stored in the Amadeus system using our Retrieve Travel Record API."
+      summary: "Travel Record Retrieve - Enable travelers to explore the details of their journeys stored in the Amadeus system using our Retrieve Travel Record API."
       description: |
         <p>Note: This API requires the use of HTTPS</p>
 
@@ -1250,7 +1250,7 @@ paths:
   /travel-intelligence/top-destinations:
     get:
       operationId: Top Flight Destinations
-      summary: The Top Flight Destinations API lets you find the most popular flight destinations from an origin during a period. This can help you answer questions like "Where are most people going to from Paris during the month of September?" 
+      summary: Top Flight Destinations - Find the most popular flight destinations from an origin during a period. This can help you answer questions like "Where are most people going to from Paris during the month of September?" 
       description: |
         <p>The Top Flight Destinations API lets you find the most popular flight destinations from an origin during a period. This can help you answer questions like "Where are most people from Paris going to during the month of September?" The API is based on estimated flight traffic summary data from two journey points over a specific period. It returns up to 50 results, ordered by popularity, showing number of travelers as well as number of flights.</p>
        
@@ -1291,7 +1291,7 @@ paths:
   /travel-intelligence/top-searches:
     get:
       operationId: Top Flight Searches
-      summary: The Top Flight Searches API lets you find the most popular flight searches from an origin in a during given search period. This can help you answer questions like "Where are people looking to travel from Paris during the month of September?" 
+      summary: Top Flight Searches - Find the most popular flight searches from an origin in a during given search period. This can help you answer questions like "Where are people looking to travel from Paris during the month of September?" 
       description: |
           <p>The Top Flight Search allows you to find number of estimated searches from an origin, optionally a destination, within a time period when travelers are performing the searches.</p> 
           <p>The search is based on queries performed from within a country (also refers to as market) and returns up to 50 results, ordered by popularity, showing number of searches for most searched destination with its previous year comparison. This search also shows patterns on how travelers are searching for flights, revealing where, when and for how long they’re planning to travel. See
@@ -1347,7 +1347,7 @@ paths:
   /travel-intelligence/flight-traffic:
     get:
       operationId: Flight Traffic API
-      summary: The Flight Traffic API lets you find the true origin and destination traffic summary between two journey points over a specified period. This can help you answer questions like "What cities are people coming from to visit Los Angeles between January through April of 2015" 
+      summary: Flight Traffic API - Find the true origin and destination traffic summary between two journey points over a specified period. This can help you answer questions like "What cities are people coming from to visit Los Angeles between January through April of 2015" 
       description: |
         <p>The Flight Traffic API lets you find the origin and destination traffic summary between two journey points over a specified period.</p>
         <p>The search returns number of flights & travelers for each origin and destination, ordered by popularity, for each month specified within the search period. This search can help you answer questions like "Where are people from Los Angeles traveling to between January and April of 2015?" or "Which is the most popular month for New Yorkers to travel last year?". </p>
@@ -1394,7 +1394,7 @@ paths:
   /points-of-interest/yapq-search-text:
     get:
       operationId: YapQ City Name Search
-      summary: Use YapQ's Point of Interest service to find landmarks and attractions in a given city.
+      summary: YapQ City Name Search - Find landmarks and attractions in a given city.
       description: |
          Amadeus has partnered with <a href="http://yapq.io/">YapQ</a> to bring you point of interest APIs with the goal of offering you unbiased ratings of landmarks and tourist attractions. YapQ rates these points according to their interest on social media and provides Wikipedia content and Geonames ID in a given city. <br />
          YapQ's service indexes millions of points around the world, and provides content in 12 different languages. This allows you to ensure you catch the <em>must-see</em> sights in a <a href="http://yapq.io/cities.html">YapQ supported city</a>.<br />
@@ -1475,7 +1475,7 @@ paths:
   /points-of-interest/yapq-search-circle:
     get:
       operationId: YapQ Geosearch
-      summary: Use YapQ's Point of Interest service to find landmarks and attractions near a given point.
+      summary: YapQ Geosearch - Find landmarks and attractions near a given point.
       description: |
          Amadeus has partnered with <a href="http://yapq.io/">YapQ</a> to bring you point of interest APIs with the goal of offering you unbiased ratings of landmarks and tourist attractions. YapQ rates places according to their interest on social media and provides Wikipedia content and Geonames ID at a given location. <br />
          YapQ's service indexes millions of points around the world, and provides content in 12 different languages. This allows you to ensure you catch the <em>must-see</em> sights at a specific <a href="http://yapq.io/cities.html">YapQ supported location</a>.<br />


### PR DESCRIPTION
The summary elements should start with the name of the API in question, since the operationID is not displayed by Postman (which is one of only 2 consumers of these summary elements) and because can only show about 30 characters by default.
This will make our Postman collection much more user-friendly.

For this pull request, please check that the new summary texts for each API make sense, are readable and have good grammar / spelling
